### PR TITLE
Update tests for PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "padraic/humbug_get_contents": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "^5.7|^6.0"
     },
     "autoload": {
         "psr-4": { "Humbug\\SelfUpdate\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "padraic/humbug_get_contents": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": { "Humbug\\SelfUpdate\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "padraic/humbug_get_contents": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0"
+        "phpunit/phpunit": "^4.0|^5.7|^6.0"
     },
     "autoload": {
         "psr-4": { "Humbug\\SelfUpdate\\": "src/" }

--- a/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
@@ -11,10 +11,11 @@
 
 namespace Humbug\Test\SelfUpdate;
 
+use PHPUnit\Framework\TestCase;
 use Humbug\SelfUpdate\Updater;
 use Humbug\SelfUpdate\Strategy\GithubStrategy;
 
-class UpdaterGithubStrategyTest extends \PHPUnit_Framework_TestCase
+class UpdaterGithubStrategyTest extends TestCase
 {
 
     private $files;
@@ -88,7 +89,7 @@ class UpdaterGithubStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testSetStabilityThrowsExceptionOnInvalidStabilityValue()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'Humbug\\SelfUpdate\\Exception\\InvalidArgumentException'
         );
         $this->updater->getStrategy()->setStability('foo');

--- a/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
@@ -87,11 +87,11 @@ class UpdaterGithubStrategyTest extends TestCase
         );
     }
 
+    /**
+     * @expectedException Humbug\SelfUpdate\Exception\InvalidArgumentException
+     */
     public function testSetStabilityThrowsExceptionOnInvalidStabilityValue()
     {
-        $this->expectException(
-            'Humbug\\SelfUpdate\\Exception\\InvalidArgumentException'
-        );
         $this->updater->getStrategy()->setStability('foo');
     }
 

--- a/tests/Humbug/Test/SelfUpdate/UpdaterTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterTest.php
@@ -58,9 +58,11 @@ class UpdaterTest extends TestCase
         );
     }
 
+    /**
+     * @expectedException Humbug\SelfUpdate\Exception\RuntimeException
+     */
     public function testConstructorThrowsExceptionIfPubKeyNotExistsButFlagTrue()
     {
-        $this->expectException('Humbug\\SelfUpdate\\Exception\\RuntimeException');
         $updater = new Updater($this->files . '/test-nopubkey.phar');
     }
 
@@ -79,9 +81,11 @@ class UpdaterTest extends TestCase
         $this->assertEquals($this->updater->getStrategy()->getPharUrl(), 'https://www.example.com');
     }
 
+    /**
+     * @expectedException Humbug\SelfUpdate\Exception\InvalidArgumentException
+     */
     public function testSetPharUrlThrowsExceptionOnInvalidUrl()
     {
-        $this->expectException('Humbug\\SelfUpdate\\Exception\\InvalidArgumentException');
         $this->updater->getStrategy()->setPharUrl('silly:///home/padraic');
     }
 
@@ -94,9 +98,11 @@ class UpdaterTest extends TestCase
         $this->assertEquals($this->updater->getStrategy()->getVersionUrl(), 'https://www.example.com');
     }
 
+    /**
+     * @expectedException Humbug\SelfUpdate\Exception\InvalidArgumentException
+     */
     public function testSetVersionUrlThrowsExceptionOnInvalidUrl()
     {
-        $this->expectException('Humbug\\SelfUpdate\\Exception\\InvalidArgumentException');
         $this->updater->getStrategy()->setVersionUrl('silly:///home/padraic');
     }
 
@@ -108,22 +114,20 @@ class UpdaterTest extends TestCase
         $this->assertEquals('1af1b9c94dea1ff337587bfa9109f1dad1ec7b9b', $this->updater->getNewVersion());
     }
 
+    /**
+     * @expectedException Humbug\SelfUpdate\Exception\HttpRequestException
+     */
     public function testThrowsExceptionOnEmptyRemoteVersion()
     {
-        $this->expectException(
-            'Humbug\\SelfUpdate\\Exception\\HttpRequestException',
-            'Version request returned empty response'
-        );
         $this->updater->getStrategy()->setVersionUrl('file://' . $this->files . '/empty.version');
         $this->assertTrue($this->updater->hasUpdate());
     }
 
+    /**
+     * @expectedException Humbug\SelfUpdate\Exception\HttpRequestException
+     */
     public function testThrowsExceptionOnInvalidRemoteVersion()
     {
-        $this->expectException(
-            'Humbug\\SelfUpdate\\Exception\\HttpRequestException',
-            'Version request returned incorrectly formatted response'
-        );
         $this->updater->getStrategy()->setVersionUrl('file://' . $this->files . '/bad.version');
         $this->assertTrue($this->updater->hasUpdate());
     }
@@ -149,6 +153,7 @@ class UpdaterTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @expectedException UnexpectedValueException
      */
     public function testUpdatePharFailsIfCurrentPublicKeyEmpty()
     {
@@ -161,7 +166,6 @@ class UpdaterTest extends TestCase
         $updater->getStrategy()->setPharUrl('file://' . $this->files . '/build/new.phar');
         $updater->getStrategy()->setVersionUrl('file://' . $this->files . '/build/new.version');
 
-        $this->expectException('UnexpectedValueException');
         $updater->update();
     }
 
@@ -177,6 +181,7 @@ class UpdaterTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @expectedException UnexpectedValueException
      */
     public function testUpdatePharFailsOnExpectedSignatureMismatch()
     {
@@ -188,8 +193,6 @@ class UpdaterTest extends TestCase
         $this->assertEquals('old', $this->getPharOutput($this->tmp . '/old.phar'));
 
         /** Signature check should fail with invalid signature by a different privkey */
-        $this->expectException('UnexpectedValueException');
-
         $updater = new Updater($this->tmp . '/old.phar');
         $updater->getStrategy()->setPharUrl('file://' . $this->files . '/build/badsig.phar');
         $updater->getStrategy()->setVersionUrl('file://' . $this->files . '/build/badsig.version');
@@ -198,6 +201,7 @@ class UpdaterTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @expectedException Humbug\SelfUpdate\Exception\RuntimeException
      */
     public function testUpdatePharFailsIfDownloadPharIsUnsignedWhenExpected()
     {
@@ -207,7 +211,6 @@ class UpdaterTest extends TestCase
         $updater->getStrategy()->setVersionUrl('file://' . $this->files . '/build/nosig.version');
 
         /** If newly download phar lacks an expected signature, an exception should be thrown */
-        $this->expectException('Humbug\\SelfUpdate\\Exception\\RuntimeException');
         $updater->update();
     }
 

--- a/tests/Humbug/Test/SelfUpdate/UpdaterTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterTest.php
@@ -11,10 +11,11 @@
 
 namespace Humbug\Test\SelfUpdate;
 
+use PHPUnit\Framework\TestCase;
 use Humbug\SelfUpdate\Updater;
 use Humbug\SelfUpdate\Strategy\StrategyInterface;
 
-class UpdaterTest extends \PHPUnit_Framework_TestCase
+class UpdaterTest extends TestCase
 {
 
     private $files;
@@ -59,7 +60,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorThrowsExceptionIfPubKeyNotExistsButFlagTrue()
     {
-        $this->setExpectedException('Humbug\\SelfUpdate\\Exception\\RuntimeException');
+        $this->expectException('Humbug\\SelfUpdate\\Exception\\RuntimeException');
         $updater = new Updater($this->files . '/test-nopubkey.phar');
     }
 
@@ -80,7 +81,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPharUrlThrowsExceptionOnInvalidUrl()
     {
-        $this->setExpectedException('Humbug\\SelfUpdate\\Exception\\InvalidArgumentException');
+        $this->expectException('Humbug\\SelfUpdate\\Exception\\InvalidArgumentException');
         $this->updater->getStrategy()->setPharUrl('silly:///home/padraic');
     }
 
@@ -95,7 +96,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetVersionUrlThrowsExceptionOnInvalidUrl()
     {
-        $this->setExpectedException('Humbug\\SelfUpdate\\Exception\\InvalidArgumentException');
+        $this->expectException('Humbug\\SelfUpdate\\Exception\\InvalidArgumentException');
         $this->updater->getStrategy()->setVersionUrl('silly:///home/padraic');
     }
 
@@ -109,7 +110,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
 
     public function testThrowsExceptionOnEmptyRemoteVersion()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'Humbug\\SelfUpdate\\Exception\\HttpRequestException',
             'Version request returned empty response'
         );
@@ -119,7 +120,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
 
     public function testThrowsExceptionOnInvalidRemoteVersion()
     {
-        $this->setExpectedException(
+        $this->expectException(
             'Humbug\\SelfUpdate\\Exception\\HttpRequestException',
             'Version request returned incorrectly formatted response'
         );
@@ -160,7 +161,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
         $updater->getStrategy()->setPharUrl('file://' . $this->files . '/build/new.phar');
         $updater->getStrategy()->setVersionUrl('file://' . $this->files . '/build/new.version');
 
-        $this->setExpectedException('UnexpectedValueException');
+        $this->expectException('UnexpectedValueException');
         $updater->update();
     }
 
@@ -187,7 +188,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('old', $this->getPharOutput($this->tmp . '/old.phar'));
 
         /** Signature check should fail with invalid signature by a different privkey */
-        $this->setExpectedException('UnexpectedValueException');
+        $this->expectException('UnexpectedValueException');
 
         $updater = new Updater($this->tmp . '/old.phar');
         $updater->getStrategy()->setPharUrl('file://' . $this->files . '/build/badsig.phar');
@@ -206,7 +207,7 @@ class UpdaterTest extends \PHPUnit_Framework_TestCase
         $updater->getStrategy()->setVersionUrl('file://' . $this->files . '/build/nosig.version');
 
         /** If newly download phar lacks an expected signature, an exception should be thrown */
-        $this->setExpectedException('Humbug\\SelfUpdate\\Exception\\RuntimeException');
+        $this->expectException('Humbug\\SelfUpdate\\Exception\\RuntimeException');
         $updater->update();
     }
 

--- a/tests/Humbug/Test/SelfUpdate/VersionParserTest.php
+++ b/tests/Humbug/Test/SelfUpdate/VersionParserTest.php
@@ -11,9 +11,10 @@
 
 namespace Humbug\Test\SelfUpdate;
 
+use PHPUnit\Framework\TestCase;
 use Humbug\SelfUpdate\VersionParser;
 
-class VersionParserTest extends \PHPUnit_Framework_TestCase
+class VersionParserTest extends TestCase
 {
 
     // Stable Versions


### PR DESCRIPTION
#26 will need to be rebased if this is merged as it contains one extra testcase file.