### PR TITLE
Allow disabling updates across major versions with Github strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ If you want to ignore stability and just update to the most recent version regar
 $updater->getStrategy()->setStability('any');
 ```
 
+You can prevent updates to the next significant major version (e.g. 1.x to 2.x),
+for example, if you want the user to specifically agree to it or you have specific
+pre-conditions before doing so, using:
+
+```php
+$updater->getStrategy()->blockMajorVersionUpdates();
+```
+
 ### Rollback Support
 
 The Updater automatically copies a backup of the original phar to myname-old.phar.

--- a/src/Strategy/GithubStrategy.php
+++ b/src/Strategy/GithubStrategy.php
@@ -59,6 +59,11 @@ class GithubStrategy implements StrategyInterface
     private $stability = self::STABLE;
 
     /**
+     * @var bool
+     */
+    private $allowMajor = true;
+
+    /**
      * Download the remote Phar file.
      *
      * @param Updater $updater
@@ -101,6 +106,11 @@ class GithubStrategy implements StrategyInterface
         }
 
         $versions = array_keys($package['package']['versions']);
+
+        if (false === $this->allowMajor) {
+            $versions = $this->filterByLocalMajorVersion($versions);
+        }
+
         $versionParser = new VersionParser($versions);
         if ($this->getStability() === self::STABLE) {
             $this->remoteVersion = $versionParser->getMostRecentStable();
@@ -181,6 +191,11 @@ class GithubStrategy implements StrategyInterface
         return $this->pharName;
     }
 
+    public function blockMajorVersionUpdates()
+    {
+        $this->allowMajor = false;
+    }
+
     /**
      * Set target stability
      *
@@ -225,5 +240,21 @@ class GithubStrategy implements StrategyInterface
             $this->getPharName()
         );
         return $downloadUrl;
+    }
+
+    /**
+     * Filter a list of versions to those that match the current local version.
+     *
+     * @param string[] $versions
+     * @return string[]
+     */
+    private function filterByLocalMajorVersion(array $versions)
+    {
+        list($localMajorVersion, ) = explode('.', $this->localVersion, 2);
+
+        return array_filter($versions, function ($version) use ($localMajorVersion) {
+            list($majorVersion, ) = explode('.', $version, 2);
+            return $majorVersion === $localMajorVersion;
+        });
     }
 }


### PR DESCRIPTION
A little cross-pollination from #37 to keep features as aligned as possible within the existing behaviour.