### PR TITLE
2.0: Backwards compatibility breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,16 @@ will follow in time.
 Usage
 =====
 
-The default update strategy uses an SHA-1 hash of the current remote phar in a
+A basic strategy uses an SHA-256 hash of the current remote phar in a
 version file, and will update the local phar when this version is changed. There
 is also a Github strategy which tracks Github Releases where you can upload a
-new phar file for a release.
+new phar file for a release. If you need it for backwards compatibility, or a
+transition period, there is an alternative SHA-1 strategy.
 
-### Basic SHA-1 Strategy
+You can write custom strategies which must implement
+`\Humbug\SelfUpdate\Strategy\StrategyInterface`.
+
+### Basic SHA-256 Strategy
 
 Create your self-update command, or even an update command for some other phar
 other than the current one, and include this.
@@ -67,15 +71,20 @@ other than the current one, and include this.
  * The simplest usage assumes the currently running phar is to be updated and
  * that it has been signed with a private key (using OpenSSL).
  *
- * The first constructor parameter is the path to a phar if you are not updating
- * the currently running phar.
+ * The first constructor parameter is the strategy object, the second a boolean
+ * indicating if the phar is signed, and the third the path to a different PHAR.
+ * Only the first parameter is required.
  */
 
 use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Strategy\Sha256Strategy;
 
-$updater = new Updater();
-$updater->getStrategy()->setPharUrl('https://example.com/current.phar');
-$updater->getStrategy()->setVersionUrl('https://example.com/current.version');
+$strategy = new Sha256Strategy();
+$strategy->setPharUrl('https://example.com/current.phar');
+$strategy->setVersionUrl('https://example.com/current.version');
+
+$updater = new Updater($strategy, true);
+
 try {
     $result = $updater->update();
     echo $result ? "Updated!\n" : "No update needed!\n";
@@ -89,15 +98,19 @@ If you are not signing the phar using OpenSSL:
 
 ```php
 /**
- * The second parameter to the constructor must be false if your phars are
+ * The second parameter to the Updater constructor must be false if your phars are
  * not signed using OpenSSL.
  */
 
 use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Strategy\Sha256Strategy;
 
-$updater = new Updater(null, false);
-$updater->getStrategy()->setPharUrl('https://example.com/current.phar');
-$updater->getStrategy()->setVersionUrl('https://example.com/current.version');
+$strategy = new Sha256Strategy();
+$strategy->setPharUrl('https://example.com/current.phar');
+$strategy->setVersionUrl('https://example.com/current.version');
+
+$updater = new Updater($strategy);
+
 try {
     $result = $updater->update();
     echo $result ? "Updated!\n" : "No update needed!\n";
@@ -107,21 +120,26 @@ try {
 }
 ```
 
-If you need version information:
+If you need version information (for signed phars):
 
 ```php
 use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Strategy\Sha256Strategy;
 
-$updater = new Updater();
-$updater->getStrategy()->setPharUrl('https://example.com/current.phar');
-$updater->getStrategy()->setVersionUrl('https://example.com/current.version');
+
+$strategy = new Sha256Strategy();
+$strategy->setPharUrl('https://example.com/current.phar');
+$strategy->setVersionUrl('https://example.com/current.version');
+
+$updater = new Updater($strategy, true);
+
 try {
     $result = $updater->update();
     if ($result) {
         $new = $updater->getNewVersion();
         $old = $updater->getOldVersion();
         printf(
-            'Updated from SHA-1 %s to SHA-1 %s', $old, $new
+            'Updated from SHA-256 %s to SHA-256 %s', $old, $new
         );
     } else {
         echo "No update needed!\n";
@@ -132,9 +150,9 @@ try {
 }
 ```
 
-See the Update Strategies section for an overview of how to setup the SHA-1
+See the Update Strategies section for an overview of how to setup the SHA-256
 strategy. It's a simple to maintain choice for development or nightly versions of
-phars which are released to a specific numbered version.
+phars which do not need SemVer version comparisons for updates.
 
 ### Github Release Strategy
 
@@ -147,14 +165,17 @@ the Github Release.
  * Other than somewhat different setters for the strategy, all other operations
  * are identical.
  */
-
 use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Strategy\GithubStrategy;
 
-$updater = new Updater();
-$updater->setStrategy(Updater::STRATEGY_GITHUB);
-$updater->getStrategy()->setPackageName('myvendor/myapp');
-$updater->getStrategy()->setPharName('myapp.phar');
-$updater->getStrategy()->setCurrentLocalVersion('v1.0.1');
+
+$strategy = new GithubStrategy();
+$strategy->setPackageName('myvendor/myapp');
+$strategy->setPharName('myapp.phar');
+$strategy->setCurrentLocalVersion('v1.0.1');
+
+$updater = new Updater($strategy);
+
 try {
     $result = $updater->update();
     echo $result ? "Updated!\n" : "No update needed!\n";
@@ -199,7 +220,8 @@ use Humbug\SelfUpdate\Updater;
 /**
  * Same constructor parameters as you would use for updating. Here, just defaults.
  */
-$updater = new Updater();
+$strategy = new SomeStrategy();
+$updater = new Updater($strategy);
 try {
     $result = $updater->rollback();
     if (!$result) {
@@ -225,30 +247,23 @@ The Updater constructor is fairly simple. The three basic variations are:
 
 ```php
 /**
- * Default: Update currently running phar which has been signed.
+ * Default: Update currently running phar using passed strategy.
  */
-$updater = new Updater;
+$updater = new Updater(new SomeStrategy);
 ```
 
 ```php
 /**
- * Update currently running phar which has NOT been signed.
+ * Update currently running phar which HAS been signed.
  */
-$updater = new Updater(null, false);
-```
-
-```php
-/**
- * Use a strategy other than the default SHA Hash.
- */
-$updater = new Updater(null, false, Updater::STRATEGY_GITHUB);
+$updater = new Updater(new SomeStrategy, true);
 ```
 
 ```php
 /**
  * Update a different phar which has NOT been signed.
  */
-$updater = new Updater('/path/to/impersonatephil.phar', false);
+$updater = new Updater(new SomeStrategy, false, '/path/to/impersonatephil.phar');
 ```
 
 ### Check For Updates
@@ -263,20 +278,22 @@ where a version did exist, but `false` if not.
 
 ```php
 use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Strategy\GithubStrategy;
 
 /**
  * Configuration is identical in every way for actual updates. You can run this
  * across multiple configuration variants to get recent stable, unstable, and dev
  * versions available.
  *
- * This would configure update for an unsigned phar (second constructor must be
- * false in this case).
+ * This would configure update for an unsigned phar (second parameter must be set
+ * as `true` otherwise).
  */
-$updater = new Updater(null, false);
-$updater->setStrategy(Updater::STRATEGY_GITHUB);
-$updater->getStrategy()->setPackageName('myvendor/myapp');
-$updater->getStrategy()->setPharName('myapp.phar');
-$updater->getStrategy()->setCurrentLocalVersion('v1.0.1');
+$strategy = new GithubStrategy();
+$strategy->setPackageName('myvendor/myapp');
+$strategy->setPharName('myapp.phar');
+$strategy->setCurrentLocalVersion('v1.0.1');
+
+$updater = new Updater($strategy);
 
 try {
     $result = $updater->hasUpdate();
@@ -327,11 +344,11 @@ strategies.
 Update Strategies
 =================
 
-SHA-1 Hash Synchronisation
+SHA-256 Hash Synchronisation
 --------------------------
 
 The phar-updater package only (that will change!) supports an update strategy
-where phars are updated according to the SHA-1 hash of the current phar file
+where phars are updated according to the SHA-256 hash of the current phar file
 available remotely. This assumes the existence of only two to three remote files:
 
 * myname.phar
@@ -345,11 +362,11 @@ the hash is the very first string (if not the only string). You can generate thi
 quite easily from bash using:
 
 ```sh
-sha1sum myname.phar > myname.version
+sha256sum myname.phar > myname.version
 ```
 
 Remember to regenerate the version file for each new phar build you want to distribute.
-Using `sha1sum` adds additional data after the hash, but it's fine since the hash is
+Using `sha256sum` adds additional data after the hash, but it's fine since the hash is
 the first string in the file which is the only requirement.
 
 If using OpenSSL signing, which is very much recommended, you can also put the

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
-        "padraic/humbug_get_contents": "^1.0"
+        "php": "^5.6|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5|^6.0"

--- a/src/Strategy/GithubStrategy.php
+++ b/src/Strategy/GithubStrategy.php
@@ -68,7 +68,7 @@ class GithubStrategy implements StrategyInterface
     {
         /** Switch remote request errors to HttpRequestExceptions */
         set_error_handler(array($updater, 'throwHttpRequestException'));
-        $result = humbug_get_contents($this->remoteUrl);
+        $result = file_get_contents($this->remoteUrl);
         restore_error_handler();
         if (false === $result) {
             throw new HttpRequestException(sprintf(
@@ -90,7 +90,7 @@ class GithubStrategy implements StrategyInterface
         /** Switch remote request errors to HttpRequestExceptions */
         set_error_handler(array($updater, 'throwHttpRequestException'));
         $packageUrl = $this->getApiUrl();
-        $package = json_decode(humbug_get_contents($packageUrl), true);
+        $package = json_decode(file_get_contents($packageUrl), true);
         restore_error_handler();
 
         if (null === $package || json_last_error() !== JSON_ERROR_NONE) {

--- a/src/Strategy/Sha256Strategy.php
+++ b/src/Strategy/Sha256Strategy.php
@@ -28,7 +28,7 @@ final class Sha256Strategy extends ShaStrategyAbstract
     {
         /** Switch remote request errors to HttpRequestExceptions */
         set_error_handler(array($updater, 'throwHttpRequestException'));
-        $version = humbug_get_contents($this->getVersionUrl());
+        $version = file_get_contents($this->getVersionUrl());
         restore_error_handler();
         if (false === $version) {
             throw new HttpRequestException(sprintf(

--- a/src/Strategy/ShaStrategy.php
+++ b/src/Strategy/ShaStrategy.php
@@ -32,7 +32,7 @@ class ShaStrategy extends ShaStrategyAbstract
     {
         /** Switch remote request errors to HttpRequestExceptions */
         set_error_handler(array($updater, 'throwHttpRequestException'));
-        $version = humbug_get_contents($this->getVersionUrl());
+        $version = file_get_contents($this->getVersionUrl());
         restore_error_handler();
         if (false === $version) {
             throw new HttpRequestException(sprintf(

--- a/src/Strategy/ShaStrategyAbstract.php
+++ b/src/Strategy/ShaStrategyAbstract.php
@@ -46,7 +46,7 @@ abstract class ShaStrategyAbstract implements StrategyInterface
     {
         /** Switch remote request errors to HttpRequestExceptions */
         set_error_handler(array($updater, 'throwHttpRequestException'));
-        $result = humbug_get_contents($this->getPharUrl());
+        $result = file_get_contents($this->getPharUrl());
         restore_error_handler();
         if (false === $result) {
             throw new HttpRequestException(sprintf(

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -93,11 +93,11 @@ class Updater
     /**
      * Constructor
      *
-     * @param string $localPharFile
-     * @param bool $hasPubKey
      * @param string $strategy
+     * @param bool $hasPubKey
+     * @param string $localPharFile
      */
-    public function __construct($localPharFile = null, $hasPubKey = true, $strategy = self::STRATEGY_SHA1)
+    public function __construct(StrategyInterface $strategy, $hasPubKey = false, $localPharFile = null)
     {
         ini_set('phar.require_hash', 1);
         $this->setLocalPharFile($localPharFile);
@@ -112,7 +112,7 @@ class Updater
             $this->setLocalPubKeyFile();
         }
         $this->setTempDirectory();
-        $this->setStrategy($strategy);
+        $this->setStrategyObject($strategy);
     }
 
     /**
@@ -176,11 +176,17 @@ class Updater
         }
     }
 
+    /**
+     * @param StrategyInterface $strategy
+     */
     public function setStrategyObject(StrategyInterface $strategy)
     {
         $this->strategy = $strategy;
     }
 
+    /**
+     * @return StrategyInterface
+     */
     public function getStrategy()
     {
         return $this->strategy;
@@ -206,26 +212,41 @@ class Updater
         return $this->backupExtension;
     }
 
+    /**
+     * @return string
+     */
     public function getLocalPharFile()
     {
         return $this->localPharFile;
     }
 
+    /**
+     * @return string
+     */
     public function getLocalPharFileBasename()
     {
         return $this->localPharFileBasename;
     }
 
+    /**
+     * @return string
+     */
     public function getLocalPubKeyFile()
     {
         return $this->localPubKeyFile;
     }
 
+    /**
+     * @return string
+     */
     public function getTempDirectory()
     {
         return $this->tempDirectory;
     }
 
+    /**
+     * @return string
+     */
     public function getTempPharFile()
     {
         return $this->getTempDirectory()
@@ -233,11 +254,17 @@ class Updater
             . sprintf('%s.phar.temp', $this->getLocalPharFileBasename());
     }
 
+    /**
+     * @return string
+     */
     public function getNewVersion()
     {
         return $this->newVersion;
     }
 
+    /**
+     * @return string
+     */
     public function getOldVersion()
     {
         return $this->oldVersion;
@@ -305,16 +332,29 @@ class Updater
         return $this->restorePath;
     }
 
+    /**
+     * @param  int    $errno
+     * @param  string $errstr
+     * @throws RuntimeException
+     */
     public function throwRuntimeException($errno, $errstr)
     {
         throw new RuntimeException($errstr);
     }
 
+    /**
+     * @param  int    $errno
+     * @param  string $errstr
+     * @throws HttpRequestException
+     */
     public function throwHttpRequestException($errno, $errstr)
     {
         throw new HttpRequestException($errstr);
     }
 
+    /**
+     * @return boolean
+     */
     protected function hasPubKey()
     {
         return $this->hasPubKey;

--- a/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
@@ -22,6 +22,9 @@ class UpdaterGithubStrategyTest extends TestCase
     /** @var Updater */
     private $updater;
 
+    /** @var GithubStrategy */
+    private $strategy;
+
     private $tmp;
 
     private $data;
@@ -30,7 +33,9 @@ class UpdaterGithubStrategyTest extends TestCase
     {
         $this->tmp = sys_get_temp_dir();
         $this->files = __DIR__ . '/_files';
-        $this->updater = new Updater($this->files . '/test.phar', false, Updater::STRATEGY_GITHUB);
+
+        $this->strategy = new GithubStrategy;
+        $this->updater = new Updater($this->strategy, false, $this->files . '/test.phar');
     }
 
     public function tearDown()
@@ -40,7 +45,7 @@ class UpdaterGithubStrategyTest extends TestCase
 
     public function testConstruction()
     {
-        $updater = new Updater(null, false, Updater::STRATEGY_GITHUB);
+        $updater = new Updater($this->strategy, false);
         $this->assertTrue(
             $updater->getStrategy() instanceof GithubStrategy
         );
@@ -106,8 +111,7 @@ class UpdaterGithubStrategyTest extends TestCase
         $this->createTestPharAndKey();
         $this->assertEquals('old', $this->getPharOutput($this->tmp . '/old.phar'));
 
-        $updater = new Updater($this->tmp . '/old.phar');
-        $updater->setStrategyObject(new GithubTestStrategy);
+        $updater = new Updater(new GithubTestStrategy, true, $this->tmp . '/old.phar');
         $updater->getStrategy()->setPharName('new.phar');
         $updater->getStrategy()->setPackageName(''); // not used in this test
         $updater->getStrategy()->setCurrentLocalVersion('1.0.0');

--- a/tests/Humbug/Test/SelfUpdate/UpdaterSha256StrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterSha256StrategyTest.php
@@ -22,6 +22,9 @@ class UpdaterSha256StrategyTest extends TestCase
     /** @var Updater */
     private $updater;
 
+    /** @var Sha256Strategy */
+    private $strategy;
+
     private $tmp;
 
     private $data;
@@ -30,7 +33,9 @@ class UpdaterSha256StrategyTest extends TestCase
     {
         $this->tmp = sys_get_temp_dir();
         $this->files = __DIR__ . '/_files';
-        $this->updater = new Updater($this->files . '/test.phar', true, Updater::STRATEGY_SHA256);
+
+        $this->strategy = new Sha256Strategy;
+        $this->updater = new Updater($this->strategy, true, $this->files . '/test.phar');
     }
 
     public function teardown()
@@ -40,7 +45,7 @@ class UpdaterSha256StrategyTest extends TestCase
 
     public function testConstruction()
     {
-        $updater = new Updater(null, false, Updater::STRATEGY_SHA256);
+        $updater = new Updater($this->strategy, false);
         $this->assertTrue(
             $updater->getStrategy() instanceof Sha256Strategy
         );
@@ -127,7 +132,7 @@ class UpdaterSha256StrategyTest extends TestCase
         $this->createTestPharAndKey();
         $this->assertEquals('old', $this->getPharOutput($this->tmp . '/old.phar'));
 
-        $updater = new Updater($this->tmp . '/old.phar', true, Updater::STRATEGY_SHA256);
+        $updater = new Updater($this->strategy, true, $this->tmp . '/old.phar');
         $updater->getStrategy()->setPharUrl('file://' . $this->files . '/build/new.phar');
         $updater->getStrategy()->setVersionUrl('file://' . $this->files . '/build/new.sha256.version');
         $this->assertTrue($updater->update());


### PR DESCRIPTION
- API updated: Constructor param order changed; Accept strategy objects as required param.
- Tests and README updated.