### PR TITLE
Limit humbug_get_contents dependency to 1.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "padraic/humbug_get_contents": "^1.0"
+        "padraic/humbug_get_contents": "1.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Temporary limitation of dependency version until we handle the deprecation of global namespaced functions in the near future. On merge, the branch will be tagged for release.